### PR TITLE
Compute ssh keys fix

### DIFF
--- a/Modules/CloudCompute/utils/util_helpers.py
+++ b/Modules/CloudCompute/utils/util_helpers.py
@@ -1208,7 +1208,6 @@ def update_instance(
     
     else:
         return "Fail Start"
-
     return 1
 
 # check instance format used in the exploit module to add ssh keys

--- a/Modules/CloudCompute/utils/util_helpers.py
+++ b/Modules/CloudCompute/utils/util_helpers.py
@@ -1210,3 +1210,13 @@ def update_instance(
         return "Fail Start"
 
     return 1
+
+# check instance format used in the exploit module to add ssh keys
+def check_instance_format(instance_format):
+    # Regular expression to match the required format
+    pattern = r"^projects/[^/]+/zones/[^/]+/instances/[^/]+$"
+
+    # Match the string with the pattern
+    if re.match(pattern, instance_format):
+        return True
+    return False


### PR DESCRIPTION
The exploit_instance_ssh_keys is missing the check_instance_format function. This pull request adds the function

Command Used
```
 modules run exploit_instance_ssh_keys --instance-name projects/<project-id>/zones/<zone>/instances/<instance-name> --username roshan --ssh-key "ssh-rsa AAAAB<REDACTED>" --instance-level
```

Error seen
```
[*]------------------------------------------------------------------------------------------------------------------------[*]
[X] A generic occured while executing the module. See details below:
Traceback (most recent call last):
  File "/usr/src/gcpwn/module_actions.py", line 95, in interact_with_module
    callback = module.run_module(module_args, session, first_run = first_run, last_run = last_run)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/gcpwn/Modules/CloudCompute/Exploit/exploit_instance_ssh_keys.py", line 40, in run_module
    if check_instance_format(args.instance_name):
       ^^^^^^^^^^^^^^^^^^^^^
NameError: name 'check_instance_format' is not defined

```